### PR TITLE
Add design tests for Hibernate usage guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,6 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+/target/
+/.checkstyle
+/test-output/

--- a/pom.xml
+++ b/pom.xml
@@ -13,20 +13,20 @@
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.primefaces</groupId>
             <artifactId>primefaces</artifactId>
             <version>5.0</version>
         </dependency>
-        
+
         <dependency>
             <groupId>org.primefaces.themes</groupId>
             <artifactId>all-themes</artifactId>
             <version>1.0.10</version>
         </dependency>
-		
+
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
@@ -37,12 +37,14 @@
             <artifactId>hibernate-jpa-2.1-api</artifactId>
             <version>1.0.0.Final</version>
         </dependency>
+
+        <!-- Depedency in http://mvnrepository.com/artifact/org.hibernate/hibernate-jpamodelgen/4.3.1.Final -->
         <dependency>
-            <groupId>unknown.binary</groupId>
-            <artifactId>hibernate-jpamodelgen-4.3.1.Final</artifactId>
-            <version>SNAPSHOT</version>
-            <scope>provided</scope>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-jpamodelgen</artifactId>
+            <version>4.3.1.Final</version>
         </dependency>
+
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
@@ -67,6 +69,21 @@
             <version>1.3.1</version>
             <scope>compile</scope>
         </dependency>
+
+        <!-- DESIGN TESTS FOR HIBERNATE (by http://github.com/tacianosilva) -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.8.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>br.edu.ufcg.splab</groupId>
+            <artifactId>designtests</artifactId>
+            <version>0.9.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/nink/servico/modelos/StatusArquivos.java
+++ b/src/main/java/com/nink/servico/modelos/StatusArquivos.java
@@ -1,7 +1,7 @@
 /**
- * 
+ *
  */
-package modelos;
+package com.nink.servico.modelos;
 
 import java.io.Serializable;
 
@@ -16,13 +16,13 @@ import org.hibernate.validator.constraints.NotEmpty;
 /**
  * @author jefferson
  *
- * Essa classe é uma tabela do sistema. Necessário para gerar log em run-time para usuário final. 
+ * Essa classe é uma tabela do sistema. Necessário para gerar log em run-time para usuário final.
  */
 @Entity(name = "StatusArquivos")
 public class StatusArquivos implements Serializable {
 
 	/**
-	 * 
+	 *
 	 */
 	private static final long serialVersionUID = 1L;
 

--- a/src/test/java/designtests/hibernate/HibernateDesignTests.java
+++ b/src/test/java/designtests/hibernate/HibernateDesignTests.java
@@ -56,20 +56,6 @@ public class HibernateDesignTests {
     }
 
     /**
-     * The test verifies all entities if they follows the Rule:
-     * Override both equals(java.lang.Object) and hashCode().
-     */
-    @Test
-    public void testHashCodeAndEqualsRuleAll() {
-        rule = new HashCodeAndEqualsRule(dw);
-        rule.setClassNodes(entities);
-        softAssert.assertTrue(rule.checkRule(), "\ncheckRule Failed");
-        softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
-
-        softAssert.assertAll();
-    }
-
-    /**
      * The test verifies each persistence entity if they follows the Rule:
      * Override both equals(java.lang.Object) and hashCode().
      */

--- a/src/test/java/designtests/hibernate/HibernateDesignTests.java
+++ b/src/test/java/designtests/hibernate/HibernateDesignTests.java
@@ -1,0 +1,215 @@
+package designtests.hibernate;
+
+import java.util.Set;
+
+import org.designwizard.api.DesignWizard;
+import org.designwizard.design.ClassNode;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+import br.edu.ufcg.splab.designtests.designrules.AbstractDesignRule;
+import br.edu.ufcg.splab.designtests.designrules.HashCodeAndEqualsRule;
+import br.edu.ufcg.splab.designtests.designrules.ImplementsSerializableRule;
+import br.edu.ufcg.splab.designtests.designrules.NoArgumentConstructorRule;
+import br.edu.ufcg.splab.designtests.designrules.NoFinalClassRule;
+import br.edu.ufcg.splab.designtests.designrules.ProvideGetsSetsFieldsRule;
+import br.edu.ufcg.splab.designtests.designrules.ProvideIdentifierPropertyRule;
+import br.edu.ufcg.splab.designtests.designrules.UseInterfaceSetOrListRule;
+import br.edu.ufcg.splab.designtests.designrules.UseListCollectionRule;
+import br.edu.ufcg.splab.designtests.designrules.UseSetCollectionRule;
+import br.edu.ufcg.splab.designtests.util.PersistenceRuleUtil;
+
+/**
+ * Test class with the verification of design rules recommended by the hibernate for persistent classes.
+ * @author Taciano Morais Silva - tacianosilva@gmail.com
+ */
+public class HibernateDesignTests {
+
+    private DesignWizard dw;
+    private Set<ClassNode> entities;
+    private AbstractDesignRule rule;
+
+    private PersistenceRuleUtil util = new PersistenceRuleUtil();
+
+    private SoftAssert softAssert;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        // Design for all classes in the project.
+        dw = new DesignWizard("target/classes/");
+        // Persistence classes of the model package of the project.
+        entities = util.getClassesAnnotated(dw, "javax.persistence.Entity");
+    }
+
+    @BeforeMethod
+    public void startTest() {
+         softAssert = new SoftAssert();
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+        dw = null;
+        entities = null;
+    }
+
+    /**
+     * The test verifies all entities if they follows the Rule:
+     * Override both equals(java.lang.Object) and hashCode().
+     */
+    @Test
+    public void testHashCodeAndEqualsRuleAll() {
+        rule = new HashCodeAndEqualsRule(dw);
+        rule.setClassNodes(entities);
+        softAssert.assertTrue(rule.checkRule(), "\ncheckRule Failed");
+        softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * Override both equals(java.lang.Object) and hashCode().
+     */
+    @Test
+    public void testHashCodeAndEqualsRule() {
+        rule = new HashCodeAndEqualsRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * The classes can't to be final in classes of the Model Package.
+     * The hibernate/JPA can't to use proxies (lazy loading) with final classes.
+     * @see NoFinalClassRule
+     */
+    @Test
+    public void testNoFinalClassRule() {
+        rule = new NoFinalClassRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * A default constructor must be implemented in classes of the Model Package.
+     * All persistent classes must have a default constructor (which can be non-public)
+     * so that Hibernate can instantiate them using java.lang.reflect.Constructor.newInstance().
+     * @see NoArgumentConstructorRule
+     */
+    @Test
+    public void testNoArgumentConstructorRule() {
+        rule = new NoArgumentConstructorRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * The Serializable interface should be implementated for all classes in the Model Package.
+     * @see ImplementsSerializableRule
+     */
+    @Test
+    public void testImplementsSerializableRule() {
+        rule = new ImplementsSerializableRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * Defines getters and setters in classes of the Model Package.
+     * @see ProvideGetsSetsFieldsRule
+     */
+    @Test
+    public void testProvideGetsSetsFieldsRule() {
+        rule = new ProvideGetsSetsFieldsRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * Provide identifier Properties in classes of the Model Package.
+     * @see ProvideIdentifierPropertyRule
+     */
+    @Test
+    public void testProvideIdentifierPropertyRule() {
+        rule = new ProvideIdentifierPropertyRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * Declaration of Collection of the type Set or List in classes of the Model Package.
+     * @see UseInterfaceSetOrListRule
+     */
+    @Test
+    public void testUseInterfaceSetOrListRule() {
+        rule = new UseInterfaceSetOrListRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * Declaration of Collection of the type List in classes of the Model Package.
+     */
+    @Test
+    public void testUseListCollectionRule() {
+        rule = new UseListCollectionRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+
+    /**
+     * The test verifies each persistence entity if they follows the Rule:
+     * Declaration of Collection of the type Set in classes of the Model Package.
+     */
+    @Test
+    public void testUseSetCollectionRule() {
+        rule = new UseSetCollectionRule(dw);
+        for (ClassNode entity : entities) {
+            rule.setClassNode(entity);
+            softAssert.assertTrue(rule.checkRule(), "\nEntityFailed: " + entity.getShortName());
+            softAssert.assertEquals("", rule.getReport(), "\nreport: \n" + rule.getReport());
+        }
+        softAssert.assertAll();
+    }
+}


### PR DESCRIPTION
@blastin, Neste PullRequest adicionamos a classe de teste HibernateDesignTests.java que contém testes de design para às recomendações de utilização do framework Hibernate.

Nós escrevemos testes de design para as regras de modelo de domínio (regras de design para as classes persistentes) que são descritos na documentação do Hibernate Framework (Veja na https://docs.jboss.org/hibernate/orm/5.0/userGuide/en-US/html/ch02.html) e sobre a especificação JPA.

Para a execução de testes de design, usamos a DesignWizard API (http://designwizard.org/) e o framework TestNG para testes de unidade (http://testng.org). O DesignWizard extrai as informações de design do código binário e permite escrever regras de design. O TestNG foi usado para implementar os testes de design como os testes de unidade. Ele também permite o uso de afirmações fracas (você pode usar o framework JUnit, mas ele não permite afirmações fracas).

Os testes relacionados ao uso de coleções java devem ser analisados e ser removidos quando não estiverem de acordo com a coleção utilizada (List or Set).

Os seguintes testes **falham**: _testProvideGetsSetsFieldsRule_ e _testHashCodeAndEqualsRule_. 

Gostaríamos de saber sua opnião! Obrigado!